### PR TITLE
Add master support in windows-audio-player CI

### DIFF
--- a/.github/workflows/windows-audio-player-ci.yml
+++ b/.github/workflows/windows-audio-player-ci.yml
@@ -2,9 +2,9 @@ name: windows-audio-player CI
 
 on:
   push:
-    branches: [ windows-audio-player ]
+    branches: [ master, windows-audio-player ]
   pull_request:
-    branches: [ windows-audio-player ]
+    branches: [ master, windows-audio-player ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
To support CI in `master`,  add `master` in `branches` option.

> Note: この変更はすでに`master`で行われていますが、将来の編集を考慮し、`windows-audio-player`ブランチでも変更したため、再度Mergeを行います。